### PR TITLE
add rss feed with @11ty/eleventy-plugin-rss

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,5 @@
 const dateFns = require("date-fns");
+const pluginRss = require("@11ty/eleventy-plugin-rss");
 const pluginSEO = require("eleventy-plugin-seo");
 const path = require("node:path");
 const fs = require("node:fs/promises");
@@ -17,12 +18,9 @@ module.exports = function (eleventyConfig) {
     "./node_modules/baseline-status/baseline-status.min.js": "js/baseline-status.min.js"
   });
 
-  eleventyConfig.addPlugin(pluginSEO, {
-    title: "Jschof.dev",
-    description: "I love to collaborate and solve problems.",
-    url: "https://jschof.dev",
-    author: "Jim Schofield",
-  });
+  eleventyConfig.addPlugin(pluginSEO, require("./src/_data/seo.json"));
+
+  eleventyConfig.addPlugin(pluginRss);
 
   eleventyConfig.addPlugin(highlightPlugin);
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@11ty/eleventy": "^2.0.1"
+    "@11ty/eleventy": "^2.0.1",
+    "@11ty/eleventy-plugin-rss": "1.2.0"
   },
   "dependencies": {
     "baseline-status": "^1.0.7",

--- a/src/_data/seo.json
+++ b/src/_data/seo.json
@@ -1,0 +1,6 @@
+{
+  "title": "Jschof.dev",
+  "description": "I love to collaborate and solve problems.",
+  "url": "https://jschof.dev",
+  "author": "Jim Schofield"
+}

--- a/src/feed.njk
+++ b/src/feed.njk
@@ -1,0 +1,26 @@
+---
+permalink: feed.xml
+eleventyExcludeFromCollections: true
+language: en
+---
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xml:base="{{ seo.url }}" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ seo.title }}</title>
+    <link>{{ seo.url }}</link>
+    <atom:link href="{{ permalink | absoluteUrl(seo.url) }}" rel="self" type="application/rss+xml" />
+    <description>{{ seo.description }}</description>
+    <language>{{ language }}</language>
+    {%- for post in collections.posts | reverse %}
+    {%- set absolutePostUrl = post.url | absoluteUrl(seo.url) %}
+    <item>
+      <title>{{ post.data.title }}</title>
+      <link>{{ absolutePostUrl }}</link>
+      <description>{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</description>
+      <pubDate>{{ post.date | dateToRfc822 }}</pubDate>
+      <dc:creator>{{ seo.author }}</dc:creator>
+      <guid>{{ absolutePostUrl }}</guid>
+    </item>
+    {%- endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
hey @JimSchofield! Hope this finds you well. I really have been enjoying your writing on web components after seeing your most recent post in the [Bluesky web components feed that I follow](https://bsky.app/profile/iplayitofflegit.bsky.social/feed/web-components). I was wondering if you'd be open to setting up a RSS feed for your posts so that I can subscribe to it and get notified of all your latest writing! I noticed your site was built on 11ty and figured I'd scaffold out the small updates that would be required to get it added 🙂. Feel free to disregard if it's not something you're interested in, this only took me a few minutes to put together (I've done it for my personal site as well which is built on Eleventy). Only thing to note is that I had to pin the `@11ty/eleventy-plugin-rss` version to the latest `1.x.x` version since `2+` requires Eleventy 3.0, so it's pinned to `1.2.0` in the `package.json`. Looking forward to your future writing on web components!